### PR TITLE
fix [compat]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,9 +13,9 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
-CSV = "^0.8.2"
+CSV = "0.8, 0.9"
 DataFrames = "^1.3.1"
-HTTP = "^0.9.17"
-JSON = "^0.21.1"
+HTTP = "0.9"
+JSON = "0.21"
 Reexport = "^1.2.2"
 julia = "^1.7"


### PR DESCRIPTION
caret form does not work with ver 0 the way that it does with ver 1+.
The current lines cause other packages to be replaced with earlier versions.